### PR TITLE
[Feature] 여행 일정 확정 및 저장

### DIFF
--- a/api/src/main/java/com/freepath/controller/schedule/ScheduleController.java
+++ b/api/src/main/java/com/freepath/controller/schedule/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.freepath.controller.schedule;
 
-import com.freepath.controller.schedule.response.SchedulePeriodResponse;
+import com.freepath.controller.schedule.dto.request.SaveScheduleRequest;
+import com.freepath.controller.schedule.dto.response.SchedulePeriodResponse;
 import com.freepath.schedule.component.ScheduleService;
 import com.freepath.schedule.domain.Schedule;
 import com.freepath.support.response.ApiResponse;
@@ -9,6 +10,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,5 +35,11 @@ public class ScheduleController {
                 .collect(Collectors.toList());
 
         return ApiResponse.success(schedulePeriodResponses);
+    }
+
+    @Operation(summary = "여행 일정 확정")
+    @PostMapping("/")
+    public ApiResponse<Long> saveSchedule(@RequestBody SaveScheduleRequest scheduleRequest) {
+        return ApiResponse.success(scheduleService.saveSchedule(scheduleRequest.toCoreRequest()));
     }
 }

--- a/api/src/main/java/com/freepath/controller/schedule/dto/request/DailyScheduleRequest.java
+++ b/api/src/main/java/com/freepath/controller/schedule/dto/request/DailyScheduleRequest.java
@@ -1,0 +1,17 @@
+package com.freepath.controller.schedule.dto.request;
+
+import com.freepath.schedule.dto.reqeust.DailyScheduleCoreRequest;
+import java.time.LocalDate;
+import java.util.List;
+
+public record DailyScheduleRequest(
+        LocalDate scheduleAt,
+        List<Long> destinationIds
+) {
+    public DailyScheduleCoreRequest toCoreRequest() {
+        return new DailyScheduleCoreRequest(
+                this.scheduleAt,
+                this.destinationIds
+        );
+    }
+}

--- a/api/src/main/java/com/freepath/controller/schedule/dto/request/SaveScheduleRequest.java
+++ b/api/src/main/java/com/freepath/controller/schedule/dto/request/SaveScheduleRequest.java
@@ -1,0 +1,23 @@
+package com.freepath.controller.schedule.dto.request;
+
+import com.freepath.schedule.dto.reqeust.SaveScheduleCoreRequest;
+import java.util.List;
+
+public record SaveScheduleRequest(
+        List<Integer> age,
+        List<String> disabilities,
+        Integer totalPeople,
+        List<DailyScheduleRequest> schedules
+) {
+    // SaveScheduleRequest를 SaveScheduleCoreRequest로 변환하는 메서드
+    public SaveScheduleCoreRequest toCoreRequest() {
+        return new SaveScheduleCoreRequest(
+                this.age,
+                this.disabilities,
+                this.totalPeople,
+                this.schedules.stream()
+                        .map(DailyScheduleRequest::toCoreRequest)
+                        .toList()
+        );
+    }
+}

--- a/api/src/main/java/com/freepath/controller/schedule/dto/response/SchedulePeriodResponse.java
+++ b/api/src/main/java/com/freepath/controller/schedule/dto/response/SchedulePeriodResponse.java
@@ -1,4 +1,4 @@
-package com.freepath.controller.schedule.response;
+package com.freepath.controller.schedule.dto.response;
 
 import com.freepath.schedule.domain.Schedule;
 

--- a/application-core/src/main/java/com/freepath/schedule/component/ScheduleService.java
+++ b/application-core/src/main/java/com/freepath/schedule/component/ScheduleService.java
@@ -1,7 +1,14 @@
 package com.freepath.schedule.component;
 
+import com.freepath.disability.Disability;
+import com.freepath.schedule.domain.NewSchedule;
+import com.freepath.schedule.domain.NewScheduledDisability;
+import com.freepath.schedule.domain.NewScheduledPlace;
 import com.freepath.schedule.domain.Schedule;
+import com.freepath.schedule.dto.reqeust.DailyScheduleCoreRequest;
+import com.freepath.schedule.dto.reqeust.SaveScheduleCoreRequest;
 import com.freepath.schedule.repository.ScheduleRepository;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,7 +18,48 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ScheduleService {
     private final ScheduleRepository scheduleRepository;
+
     public List<Schedule> getBookedDates(int month) {
         return scheduleRepository.getSchedulePeriodOnMonth(month);
+    }
+
+    public Long saveSchedule(SaveScheduleCoreRequest saveScheduleCoreRequest) {
+        // 여행 일정 저장 로직
+        Long scheduleId = scheduleRepository.saveSchedule(new NewSchedule(
+                1L,
+                saveScheduleCoreRequest.schedules().getFirst().scheduleAt().atStartOfDay(),
+                saveScheduleCoreRequest.schedules().getLast().scheduleAt().atStartOfDay(),
+                saveScheduleCoreRequest.totalPeople()
+        ));
+
+        // 여행 일정에 포함된 여행지 저장 로직
+        List<NewScheduledPlace> scheduledPlaces = new ArrayList<>();
+        for (DailyScheduleCoreRequest dailyScheduleCoreRequest : saveScheduleCoreRequest.schedules()) {
+            int sequenceIdx = 0;
+            for (Long placeId : dailyScheduleCoreRequest.destinationIds()) {
+                scheduledPlaces.add(new NewScheduledPlace(
+                        placeId,
+                        scheduleId,
+                        dailyScheduleCoreRequest.scheduleAt().atStartOfDay(),
+                        sequenceIdx++
+                ));
+            }
+        }
+        scheduleRepository.saveAllScheduledPlace(scheduledPlaces);
+
+        // 여행 일정 시 장애 종류 로직
+        List<NewScheduledDisability> scheduledDisabilities = new ArrayList<>();
+        for (String disability : saveScheduleCoreRequest.disabilities()) {
+            if (!Disability.existType(disability)) {
+                throw new RuntimeException("일치하는 타입이 없습니다.");
+            }
+            scheduledDisabilities.add(new NewScheduledDisability(
+                    scheduleId,
+                    disability
+            ));
+        }
+        scheduleRepository.saveAllScheduledDisability(scheduledDisabilities);
+
+        return scheduleId;
     }
 }

--- a/application-core/src/main/java/com/freepath/schedule/dto/reqeust/DailyScheduleCoreRequest.java
+++ b/application-core/src/main/java/com/freepath/schedule/dto/reqeust/DailyScheduleCoreRequest.java
@@ -1,0 +1,10 @@
+package com.freepath.schedule.dto.reqeust;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DailyScheduleCoreRequest(
+        LocalDate scheduleAt,
+        List<Long> destinationIds
+) {
+}

--- a/application-core/src/main/java/com/freepath/schedule/dto/reqeust/SaveScheduleCoreRequest.java
+++ b/application-core/src/main/java/com/freepath/schedule/dto/reqeust/SaveScheduleCoreRequest.java
@@ -1,0 +1,11 @@
+package com.freepath.schedule.dto.reqeust;
+
+import java.util.List;
+
+public record SaveScheduleCoreRequest(
+        List<Integer> age,
+        List<String> disabilities,
+        Integer totalPeople,
+        List<DailyScheduleCoreRequest> schedules
+) {
+}

--- a/domain/src/main/java/com/freepath/disability/Disability.java
+++ b/domain/src/main/java/com/freepath/disability/Disability.java
@@ -1,0 +1,28 @@
+package com.freepath.disability;
+
+import java.util.Arrays;
+
+public enum Disability {
+    // 점자 블록
+    BRAILLE_BLOCK,
+    BRAILLE_PROMOTION,
+
+    AUDIO_GUIDE,
+    HELP_DOG,
+    WHEELCHAIR,
+    ELEVATOR,
+    // 유모차
+    STROLLER,
+    GUIDE_HUMAN,
+    // 수화안내
+    SIGN_GUIDE;
+
+    public static boolean existType(String disability) {
+        for (Disability disabilityEnum : Disability.values()) {
+            if (disability.equals(disabilityEnum.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/domain/src/main/java/com/freepath/schedule/domain/NewSchedule.java
+++ b/domain/src/main/java/com/freepath/schedule/domain/NewSchedule.java
@@ -1,0 +1,11 @@
+package com.freepath.schedule.domain;
+
+import java.time.LocalDateTime;
+
+public record NewSchedule(
+        Long userId,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        int totalPeople
+) {
+}

--- a/domain/src/main/java/com/freepath/schedule/domain/NewScheduledDisability.java
+++ b/domain/src/main/java/com/freepath/schedule/domain/NewScheduledDisability.java
@@ -1,0 +1,9 @@
+package com.freepath.schedule.domain;
+
+import com.freepath.disability.Disability;
+
+public record NewScheduledDisability(
+        Long scheduleId,
+        String disability
+) {
+}

--- a/domain/src/main/java/com/freepath/schedule/domain/NewScheduledPlace.java
+++ b/domain/src/main/java/com/freepath/schedule/domain/NewScheduledPlace.java
@@ -1,0 +1,11 @@
+package com.freepath.schedule.domain;
+
+import java.time.LocalDateTime;
+
+public record NewScheduledPlace(
+        Long placeId,
+        Long scheduleId,
+        LocalDateTime scheduledAt,
+        int sequencePlace
+) {
+}

--- a/domain/src/main/java/com/freepath/schedule/domain/ScheduledDisability.java
+++ b/domain/src/main/java/com/freepath/schedule/domain/ScheduledDisability.java
@@ -1,0 +1,10 @@
+package com.freepath.schedule.domain;
+
+import com.freepath.disability.Disability;
+
+public record ScheduledDisability(
+        Long id,
+        Long scheduleId,
+        Disability disability
+) {
+}

--- a/domain/src/main/java/com/freepath/schedule/domain/ScheduledPlace.java
+++ b/domain/src/main/java/com/freepath/schedule/domain/ScheduledPlace.java
@@ -1,0 +1,10 @@
+package com.freepath.schedule.domain;
+
+public record ScheduledPlace(
+        Long id,
+        Long placeId,
+        Long scheduleId,
+        int scheduledAt,
+        int sequencePlace
+) {
+}

--- a/domain/src/main/java/com/freepath/schedule/repository/ScheduleRepository.java
+++ b/domain/src/main/java/com/freepath/schedule/repository/ScheduleRepository.java
@@ -1,5 +1,8 @@
 package com.freepath.schedule.repository;
 
+import com.freepath.schedule.domain.NewSchedule;
+import com.freepath.schedule.domain.NewScheduledDisability;
+import com.freepath.schedule.domain.NewScheduledPlace;
 import com.freepath.schedule.domain.Schedule;
 
 import java.util.List;
@@ -8,4 +11,10 @@ public interface ScheduleRepository {
 
     // 해당 월에 계획된 여행 일정 조회
     List<Schedule> getSchedulePeriodOnMonth(int month);
+
+    Long saveSchedule(NewSchedule newSchedule);
+
+    void saveAllScheduledPlace(List<NewScheduledPlace> newScheduledPlace);
+
+    void saveAllScheduledDisability(List<NewScheduledDisability> newScheduledDisability);
 }

--- a/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduleCoreRepository.java
+++ b/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduleCoreRepository.java
@@ -47,6 +47,9 @@ public class ScheduleCoreRepository implements ScheduleRepository {
 
     @Override
     public void saveAllScheduledDisability(List<NewScheduledDisability> newScheduledDisability) {
-        return;
+        List<ScheduledDisabilityEntity> scheduledDisabilityEntities = newScheduledDisability.stream()
+                .map(ScheduledDisabilityEntity::new)
+                .collect(Collectors.toList());
+        disabilityJpaRepository.saveAll(scheduledDisabilityEntities);
     }
 }

--- a/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduleCoreRepository.java
+++ b/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduleCoreRepository.java
@@ -39,7 +39,10 @@ public class ScheduleCoreRepository implements ScheduleRepository {
 
     @Override
     public void saveAllScheduledPlace(List<NewScheduledPlace> newScheduledPlaces) {
-        return;
+        List<ScheduledPlaceEntity> scheduledPlaceEntities = newScheduledPlaces.stream()
+                .map(ScheduledPlaceEntity::new)
+                .collect(Collectors.toList());
+        placeJpaRepository.saveAll(scheduledPlaceEntities);
     }
 
     @Override

--- a/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduleCoreRepository.java
+++ b/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduleCoreRepository.java
@@ -1,8 +1,10 @@
 package com.freepath.schedule;
 
+import com.freepath.schedule.domain.NewSchedule;
+import com.freepath.schedule.domain.NewScheduledDisability;
+import com.freepath.schedule.domain.NewScheduledPlace;
 import com.freepath.schedule.domain.Schedule;
 import com.freepath.schedule.repository.ScheduleRepository;
-import java.sql.Timestamp;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -13,6 +15,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ScheduleCoreRepository implements ScheduleRepository {
     private final ScheduleJpaRepository scheduleJpaRepository;
+    private final ScheduledPlaceJpaRepository placeJpaRepository;
+
+    private final ScheduledDisabilityJpaRepository disabilityJpaRepository;
 
     @Override
     public List<Schedule> getSchedulePeriodOnMonth(int month) {
@@ -20,10 +25,25 @@ public class ScheduleCoreRepository implements ScheduleRepository {
         for (ScheduleEntity s : scheduleEntities) {
             System.out.println(s.getStartAt());
         }
-        
+
         return scheduleJpaRepository.getScheduleInMonth(2024, month)
                 .stream()
                 .map(ScheduleEntity::toSchedule)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Long saveSchedule(NewSchedule newSchedule) {
+        return scheduleJpaRepository.save(new ScheduleEntity(newSchedule)).getId();
+    }
+
+    @Override
+    public void saveAllScheduledPlace(List<NewScheduledPlace> newScheduledPlaces) {
+        return;
+    }
+
+    @Override
+    public void saveAllScheduledDisability(List<NewScheduledDisability> newScheduledDisability) {
+        return;
     }
 }

--- a/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduleEntity.java
+++ b/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduleEntity.java
@@ -1,6 +1,7 @@
 package com.freepath.schedule;
 
 import com.freepath.BaseEntity;
+import com.freepath.schedule.domain.NewSchedule;
 import com.freepath.schedule.domain.Schedule;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -23,11 +24,11 @@ public class ScheduleEntity extends BaseEntity {
     protected ScheduleEntity() {
     }
 
-    public ScheduleEntity(Long userId, LocalDateTime startAt, LocalDateTime endAt, int totalPeople) {
-        this.userId = userId;
-        this.startAt = startAt;
-        this.endAt = endAt;
-        this.totalPeople = totalPeople;
+    public ScheduleEntity(NewSchedule schedule) {
+        this.userId = schedule.userId();
+        this.startAt = schedule.startAt();
+        this.endAt = schedule.endAt();
+        this.totalPeople = schedule.totalPeople();
     }
 
     public Schedule toSchedule() {

--- a/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduleJpaRepository.java
+++ b/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduleJpaRepository.java
@@ -10,4 +10,3 @@ public interface ScheduleJpaRepository extends JpaRepository<ScheduleEntity, Lon
             + "AND (YEAR(s.endAt) > :year OR (YEAR(s.endAt) = :year AND MONTH(s.endAt) >= :month))")
     List<ScheduleEntity> getScheduleInMonth(@Param("year") int year, @Param("month") int month);
 }
-s

--- a/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduledDisabilityEntity.java
+++ b/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduledDisabilityEntity.java
@@ -1,0 +1,22 @@
+package com.freepath.schedule;
+
+import com.freepath.BaseEntity;
+import com.freepath.schedule.domain.NewScheduledDisability;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "scheduled_disability")
+public class ScheduledDisabilityEntity extends BaseEntity {
+    private Long scheduleId;
+    private String disability;
+
+    protected ScheduledDisabilityEntity() { }
+
+    public ScheduledDisabilityEntity(NewScheduledDisability scheduledDisability) {
+        this.scheduleId = scheduledDisability.scheduleId();
+        this.disability = scheduledDisability.disability();
+    }
+}

--- a/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduledDisabilityJpaRepository.java
+++ b/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduledDisabilityJpaRepository.java
@@ -1,0 +1,6 @@
+package com.freepath.schedule;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduledDisabilityJpaRepository extends JpaRepository<ScheduledDisabilityEntity, Long> {
+}

--- a/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduledPlaceEntity.java
+++ b/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduledPlaceEntity.java
@@ -1,0 +1,27 @@
+package com.freepath.schedule;
+
+import com.freepath.BaseEntity;
+import com.freepath.schedule.domain.NewScheduledPlace;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "scheduled_place")
+public class ScheduledPlaceEntity extends BaseEntity {
+    private Long placeId;
+    private Long scheduleId;
+    private LocalDateTime scheduledAt;
+    private int sequencePlace;
+
+    protected ScheduledPlaceEntity() { }
+
+    public ScheduledPlaceEntity(NewScheduledPlace scheduledPlace) {
+        this.placeId = scheduledPlace.placeId();
+        this.scheduleId = scheduledPlace.scheduleId();
+        this.scheduledAt = scheduledPlace.scheduledAt();
+        this.sequencePlace = scheduledPlace.sequencePlace();
+    }
+}

--- a/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduledPlaceJpaRepository.java
+++ b/infrastructure/db-core/src/main/java/com/freepath/schedule/ScheduledPlaceJpaRepository.java
@@ -1,0 +1,6 @@
+package com.freepath.schedule;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduledPlaceJpaRepository extends JpaRepository<ScheduledPlaceEntity, Long> {
+}


### PR DESCRIPTION
## Summary
<!-- PR 요약 -->
여행 일정 생성 시 아래와 같은 선택값들을 바탕으로 여행 일정을 확정짓고 저장하는 기능을 구현합니다.

선택한 여행 총 인원
연령대
장애 종류값
여행지 (순서 포함)

## Descriptions
<!-- [Commit ID] : XXX 기능 추가 -->
301a3b4d48eb7f2e9af9ecfaf68347189c42512d : 여행 일정 엔티티 및 Dto 경로 수정
7848e1bc9269c988df96eafe2bec18b21d8153cb : 여행 일정 확정에 필요한 엔티티 및 Enum 정의
f8ef5a02aaa29a197277fb511483c5319b618739 : 여행 일정 저장
922c4a3ba0d8183ac43ca466c50619328d56488c : 여행 일정에 포함된 여행지 저장
8508305553f11af7bea28ea49004ce7009081c09 : 여행객들이 가진 장애 저장
